### PR TITLE
RSP-1738: Use unformatted id for orphaned payment queue

### DIFF
--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -35,9 +35,9 @@ const cardPayment = async (paymentObject, callback) => {
 		console.log('outside of async');
 
 		const ReceiptReference = transactionData.receipt_reference;
-		const PenaltyId = paymentObject.penalty_reference;
 		const VehicleRegistration = paymentObject.vehicle_reg;
 		const PenaltyType = paymentObject.penalty_type;
+		const PenaltyId = paymentObject.penalty_id;
 		// Send a message to the CPMS checking queue
 		if (!queueService) {
 			queueService = new QueueService(sqs, Constants.sqsUrl());


### PR DESCRIPTION
The public portal send the penalty reference in a formatted format for immobilisations (e.g. xxx-xxx-xxx-IM). `checkForOrphanedPayments` currently attempts to get a document with the penalty id provided (xxx-xxx-xxx-IM_IM).

Added a penalty id to the request from public portal so the correct id can be used by the function at https://github.com/dvsa/rsp-cpms-checking-workflow/blob/master/src/functions/checkForOrphanedPayments.js#L41

Related PR: https://github.com/dvsa/rsp-public-portal/pull/96