### PR TITLE
fix: Fix bug returning error message to payment service

### DIFF
--- a/src/utils/cpmsChargeback.js
+++ b/src/utils/cpmsChargeback.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
 import Constants from './constants';
-import { logAxiosError, logInfo, logError } from './logger';
+import {
+	logAxiosError, logInfo, logError, errorMessageFromAxiosError,
+} from './logger';
 
 export default (chargebackObj) => {
 	return new Promise((resolve, reject) => {
@@ -36,7 +38,8 @@ export default (chargebackObj) => {
 			resolve(chargebackResponse.data);
 		}).catch((error) => {
 			logAxiosError('CpmsChargeback', 'CPMS', error, logData);
-			reject(error.response);
+			const axiosErrorMessage = errorMessageFromAxiosError(error);
+			reject(axiosErrorMessage);
 		});
 	});
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -14,7 +14,7 @@ export function logError(logName, message) {
 	}, null, 2));
 }
 
-function errorMessageFromAxiosError(error) {
+export function errorMessageFromAxiosError(error) {
 	if (error.response) {
 		// The request was made and the server responded with a status code
 		// that falls out of the range of 2xx


### PR DESCRIPTION
## Description

- To fix error when returning error response in reverse payment service
- In the event of an error, the entire reposnse body was getting returned to the caller which was causing a `Converting circular structure to JSON` when the response body stream was attempted to be converted to JSON
- Instead of passing back whole response body, get the error message and return that in the promise rejection `Error` object
- Note, there are no unit tests covering this part of the code.

Related issue: [RSP-2055](https://dvsa.atlassian.net/browse/RSP-2055)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
