### PR TITLE
feat: Change building of names back to handler.*

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -23,7 +23,7 @@ provider:
       Resource: arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:CPMS_Launched_Payments
 functions:
   cardPayment:
-    handler: cardPayment/app.handler
+    handler: cardPayment/handler.cardPayment
     memorySize: 128
     events:
       -
@@ -50,7 +50,7 @@ functions:
                   responseModels:
                   application/json: "ErrorResponse"
   groupPayment:
-    handler: groupPayment/app.handler
+    handler: groupPayment/handler.groupPayment
     memorySize: 128
     events:
       -
@@ -78,7 +78,7 @@ functions:
                   responseModels:
                   application/json: "ErrorResponse"
   cardNotPresentPayment:
-    handler: cardNotPresentPayment/app.handler
+    handler: cardNotPresentPayment/handler.cardNotPresentPayment
     memorySize: 128
     events:
       -
@@ -105,7 +105,7 @@ functions:
                 responseModels:
                   application/json: "ErrorResponse"
   cashPayment:
-    handler: cashPayment/app.handler
+    handler: cashPayment/handler.cashPayment
     memorySize: 128
     events:
       -
@@ -132,7 +132,7 @@ functions:
                 responseModels:
                   application/json: "ErrorResponse"
   chequePayment:
-    handler: chequePayment/app.handler
+    handler: chequePayment/handler.chequePayment
     memorySize: 128
     events:
       -
@@ -159,7 +159,7 @@ functions:
                 responseModels:
                   application/json: "ErrorResponse"
   postalOrderPayment:
-    handler: postalOrderPayment/app.handler
+    handler: postalOrderPayment/handler.postalOrderPayment
     memorySize: 128
     events:
       -
@@ -186,7 +186,7 @@ functions:
                 responseModels:
                   application/json: "ErrorResponse"
   confirm:
-    handler: confirm/app.handler
+    handler: confirm/handler.confirm
     memorySize: 128
     events:
       -
@@ -213,7 +213,7 @@ functions:
                 responseModels:
                   application/json: "ErrorResponse"
   listReports:
-    handler: listReports/app.handler
+    handler: listReports/handler.listReports
     memorySize: 128
     events:
       -
@@ -223,7 +223,7 @@ functions:
           authorizer: aws_iam
           cors: true
   generateReport:
-    handler: generateReport/app.handler
+    handler: generateReport/handler.generateReport
     memorySize: 128
     events:
       -
@@ -233,7 +233,7 @@ functions:
           authorizer: aws_iam
           cors: true
   checkReportStatus:
-    handler: checkReportStatus/app.handler
+    handler: checkReportStatus/handler.checkReportStatus
     memorySize: 128
     events:
       -
@@ -243,7 +243,7 @@ functions:
           authorizer: aws_iam
           cors: true
   reverseCard:
-    handler: reverseCard/app.handler
+    handler: reverseCard/handler.reverseCard
     memorySize: 128
     events:
       -
@@ -253,7 +253,7 @@ functions:
           authorizer: aws_iam
           cors: true
   reverseCheque:
-    handler: reverseCheque/app.handler
+    handler: reverseCheque/handler.reverseCheque
     memorySize: 128
     events:
       -
@@ -263,7 +263,7 @@ functions:
           authorizer: aws_iam
           cors: true
   downloadReport:
-    handler: downloadReport/app.handler
+    handler: downloadReport/handler.downloadReport
     memorySize: 128
     events:
       -

--- a/src/functions/cardNotPresentPayment.js
+++ b/src/functions/cardNotPresentPayment.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const cardNotPresentPayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.cardNotPresentPayment(paymentObject);
 };
 
-export default handler;
+export default cardNotPresentPayment;

--- a/src/functions/cardPayment.js
+++ b/src/functions/cardPayment.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const cardPayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -10,4 +10,4 @@ export const handler = (event) => {
 	return PaymentService.cardPayment(paymentObject);
 };
 
-export default handler;
+export default cardPayment;

--- a/src/functions/cashPayment.js
+++ b/src/functions/cashPayment.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const cashPayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.cashPayment(paymentObject);
 };
 
-export default handler;
+export default cashPayment;

--- a/src/functions/checkReportStatus.js
+++ b/src/functions/checkReportStatus.js
@@ -1,6 +1,6 @@
 import ReportService from '../services/reportService';
 
-export const handler = (event) => {
+export const checkReportStatus = (event) => {
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return ReportService.checkReportStatus(reportObject);
 };
 
-export default handler;
+export default checkReportStatus;

--- a/src/functions/chequePayment.js
+++ b/src/functions/chequePayment.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const chequePayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.chequePayment(paymentObject);
 };
 
-export default handler;
+export default chequePayment;

--- a/src/functions/confirm.js
+++ b/src/functions/confirm.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = async (event) => {
+export const confirm = async (event) => {
 	let confirmationObject = event.body;
 	if (typeof confirmationObject.receipt_reference === 'undefined') {
 		confirmationObject = JSON.parse(event.body);
@@ -10,4 +10,4 @@ export const handler = async (event) => {
 	return PaymentService.confirmPayment(confirmationObject);
 };
 
-export default handler;
+export default confirm;

--- a/src/functions/downloadReport.js
+++ b/src/functions/downloadReport.js
@@ -1,6 +1,6 @@
 import ReportService from '../services/reportService';
 
-export const handler = (event) => {
+export const downloadReport = (event) => {
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return ReportService.downloadReport(reportObject);
 };
 
-export default handler;
+export default downloadReport;

--- a/src/functions/generateReport.js
+++ b/src/functions/generateReport.js
@@ -1,6 +1,6 @@
 import ReportService from '../services/reportService';
 
-export const handler = (event) => {
+export const generateReport = (event) => {
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);
@@ -10,4 +10,4 @@ export const handler = (event) => {
 	return ReportService.generateReport(reportObject);
 };
 
-export default handler;
+export default generateReport;

--- a/src/functions/groupPayment.js
+++ b/src/functions/groupPayment.js
@@ -1,6 +1,6 @@
 import GroupPaymentService from '../services/groupPaymentService';
 
-export const handler = (event) => {
+export const groupPayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -10,4 +10,4 @@ export const handler = (event) => {
 	return GroupPaymentService.groupPayment(paymentObject);
 };
 
-export default handler;
+export default groupPayment;

--- a/src/functions/listReports.js
+++ b/src/functions/listReports.js
@@ -1,6 +1,6 @@
 import ReportService from '../services/reportService';
 
-export const handler = (event) => {
+export const listReports = (event) => {
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return ReportService.listReports(reportObject);
 };
 
-export default handler;
+export default listReports;

--- a/src/functions/postalOrderPayment.js
+++ b/src/functions/postalOrderPayment.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const postalOrderPayment = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.postalOrderPayment(paymentObject);
 };
 
-export default handler;
+export default postalOrderPayment;

--- a/src/functions/reverseCard.js
+++ b/src/functions/reverseCard.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const reverseCard = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.reverseCard(paymentObject);
 };
 
-export default handler;
+export default reverseCard;

--- a/src/functions/reverseCheque.js
+++ b/src/functions/reverseCheque.js
@@ -1,6 +1,6 @@
 import PaymentService from '../services/paymentService';
 
-export const handler = (event) => {
+export const reverseCheque = (event) => {
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);
@@ -9,4 +9,4 @@ export const handler = (event) => {
 	return PaymentService.reverseCheque(paymentObject);
 };
 
-export default handler;
+export default reverseCheque;

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 import '@babel/polyfill';
 import Constants from './utils/constants';
 import cardPayment from './functions/cardPayment';

--- a/template.yaml
+++ b/template.yaml
@@ -10,39 +10,39 @@ Resources:
   cardPayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: cardPayment.handler
+      Handler: cardPayment.cardPayment
   cardNotPresentPayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: cardNotPresentPayment.handler
+      Handler: cardNotPresentPayment.cardNotPresentPayment
   cashPayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: cashPayment.handler
+      Handler: cashPayment.cashPayment
   chequePayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: chequePayment.handler
+      Handler: chequePayment.chequePayment
   postalOrderPayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: postalOrderPayment.handler
+      Handler: postalOrderPayment.postalOrderPayment
   confirm:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: confirm.handler
+      Handler: confirm.confirm
   listReports:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: listReports.handler
+      Handler: listReports.listReports
   generateReport:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: generateReport.handler
+      Handler: generateReport.generateReport
   checkReportStatus:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: checkReportStatus.handler
+      Handler: checkReportStatus.checkReportStatus
   reverseCard:
     Type: "AWS::Serverless::Function"
     Properties:
@@ -50,12 +50,12 @@ Resources:
   reverseCheque:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: reverseCheque.handler
+      Handler: reverseCheque.reverseCheque
   downloadReport:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: downloadReport.handler
+      Handler: downloadReport.downloadReport
   groupPayment:
     Type: "AWS::Serverless::Function"
     Properties:
-      Handler: groupPayment.handler
+      Handler: groupPayment.groupPayment

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
+const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false, outFile: 'handler' });
 
 module.exports = {
 	// Loads the entry object from the AWS::Serverless::Function resources in your


### PR DESCRIPTION
## Description

- Change building of names back to handler.[lambda-name]
- In order to fit with existing terraform, changing the way handler names are set
- Ticket RSP-2039

Related issue: [RSP-2039](https://dvsa.atlassian.net/browse/RSP-2039)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
