### PR TITLE
fix: Fix for missing boostrapping config on startup

### DIFF
--- a/src/functions/cardNotPresentPayment.js
+++ b/src/functions/cardNotPresentPayment.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const cardNotPresentPayment = (event) => {
+export const cardNotPresentPayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/cardPayment.js
+++ b/src/functions/cardPayment.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const cardPayment = (event) => {
+export const cardPayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/cashPayment.js
+++ b/src/functions/cashPayment.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const cashPayment = (event) => {
+export const cashPayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/checkReportStatus.js
+++ b/src/functions/checkReportStatus.js
@@ -1,6 +1,8 @@
 import ReportService from '../services/reportService';
+import Constants from '../utils/constants';
 
-export const checkReportStatus = (event) => {
+export const checkReportStatus = async (event) => {
+	await Constants.bootstrap();
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);

--- a/src/functions/chequePayment.js
+++ b/src/functions/chequePayment.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const chequePayment = (event) => {
+export const chequePayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/confirm.js
+++ b/src/functions/confirm.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
 export const confirm = async (event) => {
+	await Constants.bootstrap();
 	let confirmationObject = event.body;
 	if (typeof confirmationObject.receipt_reference === 'undefined') {
 		confirmationObject = JSON.parse(event.body);

--- a/src/functions/downloadReport.js
+++ b/src/functions/downloadReport.js
@@ -1,6 +1,8 @@
 import ReportService from '../services/reportService';
+import Constants from '../utils/constants';
 
-export const downloadReport = (event) => {
+export const downloadReport = async (event) => {
+	await Constants.bootstrap();
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);

--- a/src/functions/generateReport.js
+++ b/src/functions/generateReport.js
@@ -1,6 +1,8 @@
 import ReportService from '../services/reportService';
+import Constants from '../utils/constants';
 
-export const generateReport = (event) => {
+export const generateReport = async (event) => {
+	await Constants.bootstrap();
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);

--- a/src/functions/groupPayment.js
+++ b/src/functions/groupPayment.js
@@ -1,6 +1,8 @@
 import GroupPaymentService from '../services/groupPaymentService';
+import Constants from '../utils/constants';
 
-export const groupPayment = (event) => {
+export const groupPayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/listReports.js
+++ b/src/functions/listReports.js
@@ -1,6 +1,8 @@
 import ReportService from '../services/reportService';
+import Constants from '../utils/constants';
 
-export const listReports = (event) => {
+export const listReports = async (event) => {
+	await Constants.bootstrap();
 	let reportObject = event.body;
 	if (typeof reportObject.penalty_type === 'undefined') {
 		reportObject = JSON.parse(event.body);

--- a/src/functions/postalOrderPayment.js
+++ b/src/functions/postalOrderPayment.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const postalOrderPayment = (event) => {
+export const postalOrderPayment = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.payment_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/reverseCard.js
+++ b/src/functions/reverseCard.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const reverseCard = (event) => {
+export const reverseCard = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/functions/reverseCheque.js
+++ b/src/functions/reverseCheque.js
@@ -1,6 +1,8 @@
 import PaymentService from '../services/paymentService';
+import Constants from '../utils/constants';
 
-export const reverseCheque = (event) => {
+export const reverseCheque = async (event) => {
+	await Constants.bootstrap();
 	let paymentObject = event.body;
 	if (typeof paymentObject.penalty_type === 'undefined') {
 		paymentObject = JSON.parse(event.body);

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -1,5 +1,6 @@
 import { SQS, config } from 'aws-sdk';
 
+import { logInfo, logError } from '../utils/logger';
 import createResponse from '../utils/createResponse';
 
 import cpmsAuth from '../utils/cpmsAuth';
@@ -9,7 +10,6 @@ import cpmsChargeback from '../utils/cpmsChargeback';
 import cpmsReversal from '../utils/cpmsReversal';
 import Constants from '../utils/constants';
 import QueueService from './queueService';
-import { logError } from '../utils/logger';
 
 config.update({ region: 'eu-west-1' });
 const sqs = new SQS({ apiVersion: '2012-11-05' });
@@ -58,6 +58,7 @@ const cardNotPresentPayment = async (paymentObject) => {
 		paymentObject.penalty_type,
 		Constants.cardHolderNotPresentAuthBody(),
 	);
+	logInfo('cardNotPresentPayment', { redirectUrl: paymentObject.redirect_url });
 
 	try {
 		const transactionData = await cpmsPayment({

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -24,6 +24,9 @@ const configMetadata = {
 
 let configuration = {};
 async function bootstrap() {
+	if (Object.keys(configuration).length !== 0) {
+		return configuration;
+	}
 	return new Promise((resolve, reject) => {
 		if (process.env.USE_SECRETS_MANAGER === 'true') {
 			const SecretId = process.env.SECRETS_MANAGER_SECRET_NAME;


### PR DESCRIPTION
## Description

- The build package changes due to the Node upgrade removed the way the config (env variables) get setup when the lambda is invoked
- Add the bootsrapping back into each lambda function
- Add check to the config so the secrets are cached and not pulled in every time the lambda is invoked

Related issue: [RSP-2068](https://dvsa.atlassian.net/browse/RSP-2068)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
