### PR TITLE
feat: Add error handling for validation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.4.0",
-        "@dvsa/rsp-validation": "^1.6.1",
+        "@dvsa/rsp-validation": "^1.9.1",
         "aws-sdk": "^2.1256.0",
         "axios": "1.1.3",
         "buffer": "6.0.3",
@@ -2760,9 +2760,9 @@
       }
     },
     "node_modules/@dvsa/rsp-validation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.6.1.tgz",
-      "integrity": "sha512-mc8slTz6EhuXqNTCw0OGghfAL5wp8vzXYsIIqd/VMU/vCaUcysBGnFTei+ksdkvsf0h4OhaTp5aYisyGchkbwA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
+      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
       "dependencies": {
         "joi": "^17.7.0"
       }
@@ -5971,9 +5971,9 @@
       }
     },
     "node_modules/cron-parser/node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -9862,9 +9862,9 @@
       "dev": true
     },
     "node_modules/luxon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.1.tgz",
-      "integrity": "sha512-Ah6DloGmvseB/pX1cAmjbFvyU/pKuwQMQqz7d0yvuDlVYLTs2WeDHQMpC8tGjm1da+BriHROW/OEIT/KfYg6xw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -14245,9 +14245,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -17244,9 +17244,9 @@
       "dev": true
     },
     "@dvsa/rsp-validation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.6.1.tgz",
-      "integrity": "sha512-mc8slTz6EhuXqNTCw0OGghfAL5wp8vzXYsIIqd/VMU/vCaUcysBGnFTei+ksdkvsf0h4OhaTp5aYisyGchkbwA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
+      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
       "requires": {
         "joi": "^17.7.0"
       }
@@ -19897,9 +19897,9 @@
       },
       "dependencies": {
         "luxon": {
-          "version": "1.28.0",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-          "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+          "version": "1.28.1",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
           "dev": true
         }
       }
@@ -22862,9 +22862,9 @@
       "dev": true
     },
     "luxon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.1.tgz",
-      "integrity": "sha512-Ah6DloGmvseB/pX1cAmjbFvyU/pKuwQMQqz7d0yvuDlVYLTs2WeDHQMpC8tGjm1da+BriHROW/OEIT/KfYg6xw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
       "dev": true
     },
     "make-dir": {
@@ -26210,9 +26210,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
-    "@dvsa/rsp-validation": "^1.6.1",
+    "@dvsa/rsp-validation": "^1.9.1",
     "aws-sdk": "^2.1256.0",
     "axios": "1.1.3",
     "buffer": "6.0.3",

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -69,6 +69,7 @@ const cardNotPresentPayment = async (paymentObject) => {
 		});
 		return createResponse({ body: transactionData, statusCode: 200 });
 	} catch (err) {
+		logError('CardNotPresentPaymentError', err.message);
 		return createResponse({ body: err, statusCode: 400 });
 	}
 };
@@ -85,6 +86,7 @@ const cashPayment = async (paymentObject) => {
 		});
 		return createResponse({ body: transactionData, statusCode: 200 });
 	} catch (err) {
+		logError('CashPaymentError', err.message);
 		return createResponse({ body: err, statusCode: 400 });
 	}
 };
@@ -101,6 +103,7 @@ const chequePayment = async (paymentObject) => {
 		});
 		return createResponse({ body: transactionData, statusCode: 200 });
 	} catch (err) {
+		logError('ChequePaymentError', err.message);
 		return createResponse({ body: err, statusCode: 400 });
 	}
 };
@@ -117,6 +120,7 @@ const postalOrderPayment = async (paymentObject) => {
 		});
 		return createResponse({ body: transactionData, statusCode: 200 });
 	} catch (err) {
+		logError('PostalPaymentError', err.message);
 		return createResponse({ body: err, statusCode: 400 });
 	}
 };

--- a/src/utils/cpmsGroupPayment.js
+++ b/src/utils/cpmsGroupPayment.js
@@ -3,37 +3,35 @@ import Validation from '@dvsa/rsp-validation';
 
 import buildGroupTransactionOptions from './buildGroupTransactionOptions';
 import Constants from './constants';
-import { logAxiosError, logInfo, logError } from './logger';
+import { logAxiosError, logError } from './logger';
 
-export default (groupTransactionData) => {
-	return new Promise((resolve, reject) => {
-
-		const transactionClient = axios.create({
-			baseURL: Constants.cpmsBaseUrl(),
-			headers: {
-				'Content-Type': 'application/vnd.dvsa-gov-uk.v2+json',
-				Authorization: `Bearer ${groupTransactionData.auth.access_token}`,
-			},
-		});
-
-		const transactionOptions = buildGroupTransactionOptions(groupTransactionData);
-		const validationResult = Validation.cpmsTransactionValidation(transactionOptions);
-		if (!validationResult.valid) {
-			const errMsg = validationResult.error.message;
-			reject(errMsg);
-			return;
-		}
-		transactionClient.post(groupTransactionData.endpoint, transactionOptions)
-			.then((transactionResponse) => {
-				if (typeof transactionResponse.data === 'undefined') {
-					logError('CPMSGroupPaymentNoData', { groupTransactionData });
-					reject(new Error('Call to CPMS returned no data'));
-				}
-				logInfo('CPMSGroupPaymentSuccess', { groupTransactionData });
-				resolve(transactionResponse.data);
-			}).catch((err) => {
-				logAxiosError('CpmsGroupPayment', 'CPMS', err, { groupTransactionData });
-				throw err;
-			});
+const cpmsGroupPayment = async (groupTransactionData) => {
+	const transactionClient = axios.create({
+		baseURL: Constants.cpmsBaseUrl(),
+		headers: {
+			'Content-Type': 'application/vnd.dvsa-gov-uk.v2+json',
+			Authorization: `Bearer ${groupTransactionData.auth.access_token}`,
+		},
 	});
+
+	const transactionOptions = buildGroupTransactionOptions(groupTransactionData);
+	const validationResult = Validation.cpmsTransactionValidation(transactionOptions);
+	if (!validationResult.valid) {
+		const errMsg = validationResult.error.message;
+		logError('ValidationError', validationResult);
+		throw new Error(errMsg);
+	}
+	try {
+		const transactionResponse = await transactionClient.post(groupTransactionData.endpoint, transactionOptions);
+		if (typeof transactionResponse.data === 'undefined') {
+			logError('CPMSGroupPaymentNoData', { groupTransactionData });
+			throw new Error('Call to CPMS returned no data');
+		}
+		return transactionResponse.data;
+	} catch (err) {
+		logAxiosError('CpmsGroupPayment', 'CPMS', err, { groupTransactionData });
+		throw err;
+	}
 };
+
+export default cpmsGroupPayment;

--- a/src/utils/cpmsPayment.js
+++ b/src/utils/cpmsPayment.js
@@ -4,31 +4,32 @@ import buildTransactionOptions from './buildTransactionOptions';
 import Constants from './constants';
 import { logAxiosError, logInfo, logError } from './logger';
 
-export default (transactionData) => {
-	return new Promise((resolve, reject) => {
-
-		const transactionClient = axios.create({
-			baseURL: Constants.cpmsBaseUrl(),
-			headers: {
-				'Content-Type': 'application/vnd.dvsa-gov-uk.v2+json',
-				Authorization: `Bearer ${transactionData.auth.access_token}`,
-			},
-		});
-
-		const transactionOptions = buildTransactionOptions(transactionData);
-
-		transactionClient.post(transactionData.endpoint, transactionOptions)
-			.then((transactionResponse) => {
-				if (typeof transactionResponse.data === 'undefined') {
-					logError('CPMSPaymentNoData', { transactionOptions });
-					reject(new Error('Call to CPMS returned no data'));
-				}
-				logInfo('CPMSPaymentSuccess', { transactionOptions });
-				resolve(transactionResponse.data);
-			})
-			.catch((error) => {
-				logAxiosError('CpmsPayment', 'CPMS', error, { transactionOptions });
-				reject(error.response.data);
-			});
+const cpmsPayment = async (transactionData) => {
+	const transactionClient = axios.create({
+		baseURL: Constants.cpmsBaseUrl(),
+		headers: {
+			'Content-Type': 'application/vnd.dvsa-gov-uk.v2+json',
+			Authorization: `Bearer ${transactionData.auth.access_token}`,
+		},
 	});
+
+	const transactionOptions = buildTransactionOptions(transactionData);
+
+	try {
+		const transactionResponse = await transactionClient.post(transactionData.endpoint, transactionOptions);
+		if (typeof transactionResponse.data === 'undefined') {
+			logError('CPMSPaymentNoData', { transactionOptions });
+			throw new Error('Call to CPMS returned no data');
+		}
+		logInfo('CPMSPaymentSuccess', { transactionOptions });
+		return transactionResponse.data;
+	} catch (error) {
+		if (error.isAxiosError) {
+			logAxiosError('CpmsPayment', 'CPMS', error, { transactionOptions });
+			throw new Error(error.response.data);
+		}
+		throw new Error(error.message);
+	}
 };
+
+export default cpmsPayment;


### PR DESCRIPTION
## Description

- If a validation error is thrown, the error message wasn't getting logged or returned back to the controller because the promise rejection wasn't getting awaited correctly
- Updated code to async/await instead of resolving/rejecting promise
- Update to latest version of Validation Package which removes max penalty lines validation

Related issue: [RSP-1988](https://dvsa.atlassian.net/browse/RSP-1998)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
