### PR TITLE
fix: corrected logging issue when downloading reports

### DIFF
--- a/src/utils/downloadReport.js
+++ b/src/utils/downloadReport.js
@@ -16,11 +16,11 @@ export default async (reportObj) => {
 	return new Promise((resolve, reject) => {
 		reportStreamClient.get(`/report/${reportObj.report_ref}/download`)
 			.then((response) => {
-				logInfo('CPMSReportDownloadSuccess', { reportObj });
+				logInfo('CPMSReportDownloadSuccess', { report_ref: reportObj.report_ref });
 				resolve(response.data);
 			})
 			.catch((error) => {
-				logAxiosError('CpmsDownloadReport', 'CPMS', error, { reportObj });
+				logAxiosError('CpmsDownloadReport', 'CPMS', error, { report_ref: reportObj.report_ref });
 				reject(JSON.stringify(error));
 			});
 	});


### PR DESCRIPTION
## Description

- It was discovered that, when CPMS reports were being generated, access tokens were being inadvertendly logged out as part of an object.
- This fix corrects that, so instead of logging out the whole object, just the reference of the report is logged out.
- This fix has been applied to both success and error messages.

Related issue: [RSP-2251](https://dvsa.atlassian.net/browse/RSP-2251)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
